### PR TITLE
fix: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/deploy-ee.yml
+++ b/.github/workflows/deploy-ee.yml
@@ -53,10 +53,10 @@ jobs:
     environment: deploy
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 


### PR DESCRIPTION
## Summary
- Updates `actions/checkout` from v4 to v6
- Updates `actions/setup-python` from v5 to v6

## Context
Addresses Node.js 20 deprecation warnings in GitHub Actions workflows. Node.js 20 will be removed from GitHub runners on September 16, 2026.

## Test plan
- [x] Pre-commit hooks passed
- [ ] Run workflow to verify warnings are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)